### PR TITLE
Fix line height of tables

### DIFF
--- a/styles/index.styl
+++ b/styles/index.styl
@@ -282,7 +282,7 @@ a.header-anchor
 code, kbd, .line-number
   font-family $monoFontFamily, source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace
 
-p, ul, ol
+p, ul, ol, th, td
   line-height 1.7
 
 hr


### PR DESCRIPTION
Adjusted the table line height to match that of paragraphs. Otherwise the table content would be very crowded, and the background of code style would overlap, like on [this page](https://dortania.github.io/OpenCore-Install-Guide/terminology.html).