### PR TITLE
Fix theme inheritance

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -38,7 +38,7 @@
 
 <script>
 import AlgoliaSearchBox from '@theme/components/AlgoliaSearchBox.vue'
-import SearchBox from '@theme/components/SearchBox.vue'
+import SearchBox from '@vuepress/plugin-search/SearchBox.vue'
 import SidebarButton from '@theme/components/SidebarButton.vue'
 import NavLinks from '@theme/components/NavLinks.vue'
 

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -37,8 +37,8 @@
 </template>
 
 <script>
-import AlgoliaSearchBox from '@AlgoliaSearchBox'
-import SearchBox from '@SearchBox'
+import AlgoliaSearchBox from '@theme/components/AlgoliaSearchBox.vue'
+import SearchBox from '@theme/components/SearchBox.vue'
 import SidebarButton from '@theme/components/SidebarButton.vue'
 import NavLinks from '@theme/components/NavLinks.vue'
 


### PR DESCRIPTION
It seems theme inheritance resolving happens before Webpack aliasing, so `@AlgoliaSearchBox` and `@SearchBox` won't work when using VuePress's theme inheritance feature.